### PR TITLE
build: 🛠 allow anyio = ">=3.7.1,<5"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 python = "^3.8"
 aiosmtplib = { version = "^3.0", optional = true }
 dkimpy = { version = "^1.0", optional = true }
-anyio = "^4"
+anyio = ">=3.7.1,<5"
 jinja2 = { version = "^3.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Summary of the changes
- Change version definition of `anyio` in `pyproject.toml` from `anyio = "^4"` to `anyio = ">=3.7.1,<5"`

# Motivation

Hi @alex-oleshkevich,

thank you for making `mailers`! In my project I have a dependency on [`starlette-testclient`](https://github.com/Kludex/starlette-testclient/issues/5) that relies on `anyio` of major version `3`. `mailers` currently requires `anyio = "^4"` and I can therefore not use it together with `starlette-testclient` (apart from heavily complicating my testing setup by splitting everything into separate virtual environments).

As far as I can tell the only method from `anyio` that is being used in `mailers` is `open_file` in `mailers/message.py` and `mailers/transports/file.py`. I have checked the [`anyio` changelog](https://anyio.readthedocs.io/en/stable/versionhistory.html) to ensure that `open_file` did not receive any breaking changes between major version `3` and `4` and could not find any mention of breaking changes to that method. The unit tests are also still passing for both version `3.7.1` of `anyio` and of course major version `4` as currently inside the `pyproject.toml`.

Therefore I would like to propose with this Pull Request that `mailers` changes the version definition of `anyio` in `pyproject.toml` from `anyio = "^4"` to `anyio = ">=3.7.1,<5"`.

Please let me know what you think :)

Greetings and best wishes,
Athena