### PR TITLE
fix: 🐛 fix accidentally non-optional aiosmtplib

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## Usage
 
 ```bash
-pip install mailers[aiosmtplib]
+pip install mailers[smtp]
 ```
 
 Then create mailer:

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import aiosmtplib
 import typing
 from email.message import Message
 
@@ -29,6 +28,8 @@ class SMTPTransport(Transport):
         self._cert_file = cert_file
 
     async def send(self, message: Message) -> None:
+        import aiosmtplib
+
         await aiosmtplib.send(
             message,
             hostname=self._host,


### PR DESCRIPTION
# Summary of the changes

- change how `aiosmtplib` is imported in `mailers/transports/smtp.py` to make it actually optional


# Motivation
`aiosmtplib` is marked optional, however when choosing to not install `aiosmtplib` importing `mailers` will cause a `ModuleNotFoundError: No module named 'aiosmtplib'`. For details see #3.

# Impact
Solves #3 