### PR TITLE
Fxes on different issues

### DIFF
--- a/mailers/factories.py
+++ b/mailers/factories.py
@@ -39,6 +39,8 @@ def create_transport_from_url(url: str) -> Transport:
         use_tls = _cast_to_bool(options.get("use_tls", ""))
         key_file: typing.Optional[str] = options.get("key_file", None)
         cert_file: typing.Optional[str] = options.get("cert_file", None)
+        cert_bundle: typing.Optional[str] = options.get("cert_bundle", None)
+        validate_certs = _cast_to_bool(options.get("validate_certs", ""))
 
         from mailers.transports.smtp import SMTPTransport
 
@@ -51,6 +53,8 @@ def create_transport_from_url(url: str) -> Transport:
             timeout=timeout or 10,
             key_file=key_file,
             cert_file=cert_file,
+            cert_bundle=cert_bundle,
+            validate_certs=validate_certs,
         )
 
     raise NotRegisteredTransportError(f"Don't know how to create transport for protocol '{protocol}'.")

--- a/mailers/mailer.py
+++ b/mailers/mailer.py
@@ -91,7 +91,7 @@ class Mailer:
             headers=dict(headers) if headers else {},
             sender=sender,
             text=str(text) if text is not None else None,
-            html=str(html) if text is not None else None,
+            html=str(html) if html is not None else None,
             return_path=return_path,
             text_charset="utf-8",
             html_charset="utf-8",

--- a/mailers/message.py
+++ b/mailers/message.py
@@ -14,7 +14,7 @@ import typing
 from email.headerregistry import Address
 from email.message import EmailMessage, Message
 from email.mime.base import MIMEBase
-from email.policy import EmailPolicy
+from email.policy import SMTP
 
 from mailers.exceptions import InvalidBodyError
 
@@ -291,7 +291,7 @@ class Email:
         attachments = [a for a in self._attachments if not a.inline and not a.part]
         extra_parts = [a for a in self._attachments if a.part]
 
-        mime_message = EmailMessage(policy=EmailPolicy())
+        mime_message = EmailMessage(policy=SMTP)
 
         for header_name, header_value in headers.items():
             if not header_value:  # ignore empty headers

--- a/mailers/preprocessors/cssliner.py
+++ b/mailers/preprocessors/cssliner.py
@@ -18,7 +18,7 @@ def css_inliner(message: EmailMessage) -> EmailMessage:
         if not message["content-disposition"]:
             _process(message)
 
-    if message.get_content_type() in ["multipart/alternative", "multipart/mixed"]:
+    if message.get_content_type() in ["multipart/alternative", "multipart/mixed", "multipart/related"]:
         for part in message.get_payload():
             css_inliner(part)
 

--- a/mailers/preprocessors/cssliner.py
+++ b/mailers/preprocessors/cssliner.py
@@ -4,7 +4,7 @@ from email.message import EmailMessage, MIMEPart
 
 def _process(part: MIMEPart) -> MIMEPart:
     content = part.get_content()
-    part.set_payload(toronado.from_string(content))
+    part.set_content(toronado.from_string(content), maintype="text", subtype="html")
     return part
 
 

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -34,8 +34,12 @@ class SMTPTransport(Transport):
     async def send(self, message: Message) -> None:
         import aiosmtplib
 
-        return_path = message.get("Return-Path")
         sender = message.get("Sender")
+        if sender:
+            del message["Sender"]
+        return_path = message.get("Return-Path")
+        if return_path:
+            del message["Return-Path"]
         if sender is None and return_path:
             sender = return_path
 

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -29,7 +29,7 @@ class SMTPTransport(Transport):
         self._key_file = key_file
         self._cert_file = cert_file
         self._cert_bundle = cert_bundle
-        self._validate_certs = validate_certs or True
+        self._validate_certs = validate_certs if validate_certs is not None else True
 
     async def send(self, message: Message) -> None:
         import aiosmtplib

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -17,6 +17,8 @@ class SMTPTransport(Transport):
         timeout: int = 10,
         key_file: typing.Optional[str] = None,
         cert_file: typing.Optional[str] = None,
+        cert_bundle: typing.Optional[str] = None,
+        validate_certs: typing.Optional[bool] = None,
     ):
         self._host = host
         self._user = user
@@ -26,6 +28,8 @@ class SMTPTransport(Transport):
         self._timeout = timeout
         self._key_file = key_file
         self._cert_file = cert_file
+        self._cert_bundle = cert_bundle
+        self._validate_certs = validate_certs or True
 
     async def send(self, message: Message) -> None:
         import aiosmtplib
@@ -40,4 +44,6 @@ class SMTPTransport(Transport):
             timeout=self._timeout,
             client_key=self._key_file,
             client_cert=self._cert_file,
+            cert_bundle=self._cert_bundle,
+            validate_certs=self._validate_certs,
         )

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -34,8 +34,12 @@ class SMTPTransport(Transport):
     async def send(self, message: Message) -> None:
         import aiosmtplib
 
-        sender = message.pop("Sender")
-        return_path = message.pop("Return-Path")
+        sender = message.get("Sender")
+        if sender:
+            del message["Sender"]
+        return_path = message.get("Return-Path")
+        if return_path:
+            del message["Return-Path"]
         if sender is None and return_path:
             sender = return_path
 

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -34,12 +34,8 @@ class SMTPTransport(Transport):
     async def send(self, message: Message) -> None:
         import aiosmtplib
 
-        sender = message.get("Sender")
-        if sender:
-            del message["Sender"]
-        return_path = message.get("Return-Path")
-        if return_path:
-            del message["Return-Path"]
+        sender = message.pop("Sender")
+        return_path = message.pop("Return-Path")
         if sender is None and return_path:
             sender = return_path
 

--- a/mailers/transports/smtp.py
+++ b/mailers/transports/smtp.py
@@ -34,8 +34,14 @@ class SMTPTransport(Transport):
     async def send(self, message: Message) -> None:
         import aiosmtplib
 
+        return_path = message.get("Return-Path")
+        sender = message.get("Sender")
+        if sender is None and return_path:
+            sender = return_path
+
         await aiosmtplib.send(
             message,
+            sender=sender,
             hostname=self._host,
             port=self._port,
             use_tls=self._use_tls,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mailers"
-version = "3.0.5"
+version = "3.0.6"
 description = "Email delivery for asyncio."
 authors = ["alex.oleshkevich <alex.oleshkevich@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
The changes to return-path & sender are important.
To set a return-path, it is the sender variable of send that is used, not the header within the message than is overwritten.
When setting a Sender header, Outllok displays something like : message from Sender on behalf of From, thus removing the Sender header and using the sender parameter...

took me several hours to sort this out. But now Return-Path and/or Sender work properly on mail reception and I can now handle bounces witha Return-Path set to mail+bounces@mydomain.com